### PR TITLE
TLSv1.2 fix for issue #19

### DIFF
--- a/TabRESTMigrate/RESTHelpers/TableauServerRequestBase.cs
+++ b/TabRESTMigrate/RESTHelpers/TableauServerRequestBase.cs
@@ -43,6 +43,9 @@ abstract class TableauServerRequestBase
         byte[] byteArray = Encoding.UTF8.GetBytes(bodyText);
         request.ContentLength = byteArray.Length;
 
+        // Include TLS1.2 protocols for custom SSL/TLS settings in Tableau Server
+        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls | SecurityProtocolType.Ssl3;
+        
         // Get the request stream.
         var dataStream = request.GetRequestStream();
         // Write the data to the request stream.


### PR DESCRIPTION
The following patch should allow the application to connect with SSL v3 through TLSv1.2. I only tested the fix on my configuration which is TLSv1.2 only